### PR TITLE
Add table with best times over a given distance

### DIFF
--- a/poolview.pro
+++ b/poolview.pro
@@ -39,12 +39,15 @@ CONFIG(debug, debug|release) {
 target.path = $$PREFIX/usr/bin
 INSTALLS += target
 
-FORMS = ui/summary.ui ui/sync.ui ui/config.ui ui/upload.ui
+FORMS = ui/summary.ui ui/sync.ui ui/config.ui ui/upload.ui \
+    ui/besttimesimpl.ui
 HEADERS = src/uploadimpl.h src/syncimpl.h src/configimpl.h src/summaryimpl.h src/graphwidget.h src/datastore.h src/calendar.h \
     src/usblink.h \
     src/poolmate.h \
     src/logging.h \
-    src/FIT.hpp src/stdintfwd.hpp src/GarminConvert.hpp
+    src/FIT.hpp src/stdintfwd.hpp src/GarminConvert.hpp \
+    src/besttimesimpl.h
 SOURCES = src/uploadimpl.cpp src/syncimpl.cpp src/configimpl.cpp src/summaryimpl.cpp src/main.cpp src/graphwidget.cpp src/datastore.cpp src/poolmate.c src/calendar.cpp \
     src/usblink.cpp \
-    src/FIT.cpp src/GarminConvert.cpp
+    src/FIT.cpp src/GarminConvert.cpp \
+    src/besttimesimpl.cpp

--- a/src/besttimesimpl.cpp
+++ b/src/besttimesimpl.cpp
@@ -81,11 +81,11 @@ BestTimesImpl::BestTimesImpl(QWidget *parent) :
 {
     setupUi(this);
 
-    // not done in on_pushButton_clicked() not to override user choice
+    // not done in on_calculateButton_clicked() not to override user choice
 
     // sort by speed as the ditance might be different
     // (if number of lanes is not integer)
-    tableWidget->sortItems(5);
+    timesTable->sortItems(5);
 }
 
 void BestTimesImpl::setDataStore(const DataStore *_ds)
@@ -93,14 +93,14 @@ void BestTimesImpl::setDataStore(const DataStore *_ds)
     ds = _ds;
 }
 
-void BestTimesImpl::on_pushButton_clicked()
+void BestTimesImpl::on_calculateButton_clicked()
 {
-    tableWidget->clearContents();
-    tableWidget->setRowCount(0);
+    timesTable->clearContents();
+    timesTable->setRowCount(0);
 
     // otherwise the rows move around while they are added
     // and we set the item in the wrong place
-    tableWidget->setSortingEnabled(false);
+    timesTable->setSortingEnabled(false);
 
     const QString distStr = distanceBox->currentText();
     bool ok = false;
@@ -140,9 +140,9 @@ void BestTimesImpl::on_pushButton_clicked()
                 continue;
             }
 
-            addSet(set, w, numberOfLanes, tableWidget);
+            addSet(set, w, numberOfLanes, timesTable);
         }
     }
 
-    tableWidget->setSortingEnabled(true);
+    timesTable->setSortingEnabled(true);
 }

--- a/src/besttimesimpl.cpp
+++ b/src/besttimesimpl.cpp
@@ -1,3 +1,21 @@
+/*
+ * This file is part of PoolViewer
+ * Copyright (c) 2015 Andrea Odetti
+ *
+ * PoolViewer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * PoolViewer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PoolViewer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "besttimesimpl.h"
 #include "datastore.h"
 

--- a/src/besttimesimpl.cpp
+++ b/src/besttimesimpl.cpp
@@ -1,0 +1,130 @@
+#include "besttimesimpl.h"
+#include "datastore.h"
+
+namespace
+{
+    QTableWidgetItem * createReadOnlyItem(const QVariant & content, int horizAlignment)
+    {
+        QTableWidgetItem * item = new QTableWidgetItem();
+        item->setFlags(item->flags() ^ Qt::ItemIsEditable);
+        item->setData(Qt::DisplayRole, content);
+        item->setTextAlignment(horizAlignment | Qt::AlignVCenter);
+
+        return item;
+    }
+
+    void addSet(const Set & set, const Workout & workout, const int numberOfLanes, QTableWidget * table)
+    {
+        const int distance = workout.pool * numberOfLanes;
+        QTime duration(0, 0);
+
+        if (set.times.size() != set.lens)
+        {
+            // error, ignore set
+            return;
+        }
+
+        for (size_t i = 0; i < numberOfLanes; ++i)
+        {
+            duration = duration.addMSecs(set.times[i] * 1000.0);
+        }
+
+        const double speed = duration.msecsSinceStartOfDay() / distance / 10.0;
+        const double total = workout.pool * set.lens;
+
+        const int row = table->rowCount();
+        table->setRowCount(row + 1);
+
+        QTableWidgetItem * dateItem = createReadOnlyItem(QVariant(workout.date), Qt::AlignLeft);
+        table->setItem(row, 0, dateItem);
+
+        QTableWidgetItem * timeItem = createReadOnlyItem(QVariant(workout.time), Qt::AlignLeft);
+        table->setItem(row, 1, timeItem);
+
+        QTableWidgetItem * poolItem = createReadOnlyItem(QVariant(workout.pool), Qt::AlignRight);
+        table->setItem(row, 2, poolItem);
+
+        QTableWidgetItem * distanceItem = createReadOnlyItem(QVariant(distance), Qt::AlignRight);
+        table->setItem(row, 3, distanceItem);
+
+        QTableWidgetItem * durationItem = createReadOnlyItem(QVariant(duration.toString()), Qt::AlignRight);
+        table->setItem(row, 4, durationItem);
+
+        QTableWidgetItem * speedItem = createReadOnlyItem(QVariant(speed), Qt::AlignRight);
+        table->setItem(row, 5, speedItem);
+
+        QTableWidgetItem * totalItem = createReadOnlyItem(QVariant(total), Qt::AlignRight);
+        table->setItem(row, 6, totalItem);
+    }
+}
+
+BestTimesImpl::BestTimesImpl(QWidget *parent) :
+    QDialog(parent), ds(NULL)
+{
+    setupUi(this);
+
+    // not done in on_pushButton_clicked() not to override user choice
+
+    // sort by speed as the ditance might be different
+    // (if number of lanes is not integer)
+    tableWidget->sortItems(5);
+}
+
+void BestTimesImpl::setDataStore(const DataStore *_ds)
+{
+    ds = _ds;
+}
+
+void BestTimesImpl::on_pushButton_clicked()
+{
+    tableWidget->clearContents();
+    tableWidget->setRowCount(0);
+
+    // otherwise the rows move around while they are added
+    // and we set the item in the wrong place
+    tableWidget->setSortingEnabled(false);
+
+    const QString distStr = distanceBox->currentText();
+    bool ok = false;
+    const uint distance = distStr.toUInt(&ok);
+    if (!ok || distance == 0)
+    {
+        return;
+    }
+
+    const std::vector<Workout>& workouts = ds->Workouts();
+
+    for (size_t i = 0; i < workouts.size(); ++i)
+    {
+        const Workout & w = workouts[i];
+
+        if (w.type != "Swim" && w.type != "SwimHR")
+        {
+            continue;
+        }
+
+        const int pool = w.pool;
+
+        if (pool <= 0)
+        {
+            continue;
+        }
+
+        // this is the number of lanes to get above or equal the desired distance
+        const uint numberOfLanes = (distance + pool - 1) / pool; // round up
+
+        for (size_t j = 0; j < w.sets.size(); ++j)
+        {
+            const Set & set = w.sets[j];
+            if (set.lens < numberOfLanes)
+            {
+                // not enough in this set
+                continue;
+            }
+
+            addSet(set, w, numberOfLanes, tableWidget);
+        }
+    }
+
+    tableWidget->setSortingEnabled(true);
+}

--- a/src/besttimesimpl.h
+++ b/src/besttimesimpl.h
@@ -33,7 +33,7 @@ public:
     void setDataStore(const DataStore *_ds);
 
 private slots:
-    void on_pushButton_clicked();
+    void on_calculateButton_clicked();
 
 private:
     const DataStore *ds;

--- a/src/besttimesimpl.h
+++ b/src/besttimesimpl.h
@@ -1,0 +1,24 @@
+#ifndef BESTTIMESIMPL_H
+#define BESTTIMESIMPL_H
+
+#include "ui_besttimesimpl.h"
+
+class DataStore;
+
+class BestTimesImpl : public QDialog, private Ui::besttimesimpl
+{
+    Q_OBJECT
+
+public:
+    explicit BestTimesImpl(QWidget *parent = 0);
+
+    void setDataStore(const DataStore *_ds);
+
+private slots:
+    void on_pushButton_clicked();
+
+private:
+    const DataStore *ds;
+};
+
+#endif // BESTTIMESIMPL_H

--- a/src/besttimesimpl.h
+++ b/src/besttimesimpl.h
@@ -1,3 +1,21 @@
+/*
+ * This file is part of PoolViewer
+ * Copyright (c) 2015 Andrea Odetti
+ *
+ * PoolViewer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * PoolViewer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PoolViewer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef BESTTIMESIMPL_H
 #define BESTTIMESIMPL_H
 

--- a/src/summaryimpl.cpp
+++ b/src/summaryimpl.cpp
@@ -32,6 +32,7 @@
 #include "syncimpl.h"
 #include "datastore.h"
 #include "configimpl.h"
+#include "besttimesimpl.h"
 
 
 SummaryImpl::SummaryImpl( QWidget * parent, Qt::WindowFlags f) 
@@ -644,3 +645,11 @@ void SummaryImpl::on_check_clicked()
 
 }
 
+/* open Best Times window */
+void SummaryImpl::bestTimesButton()
+{
+    BestTimesImpl win(this);
+
+    win.setDataStore(ds);
+    win.exec();
+}

--- a/src/summaryimpl.h
+++ b/src/summaryimpl.h
@@ -68,6 +68,7 @@ public:
     virtual void scaleChanged(int);
     virtual void printButton();
     virtual void on_check_clicked();
+    virtual void bestTimesButton();
 
 private:
     DataStore *ds;

--- a/ui/besttimesimpl.ui
+++ b/ui/besttimesimpl.ui
@@ -54,7 +54,7 @@
     </widget>
    </item>
    <item row="0" column="0" colspan="4">
-    <widget class="QTableWidget" name="tableWidget">
+    <widget class="QTableWidget" name="timesTable">
      <column>
       <property name="text">
        <string>Date</string>
@@ -93,7 +93,7 @@
     </widget>
    </item>
    <item row="2" column="2">
-    <widget class="QPushButton" name="pushButton">
+    <widget class="QPushButton" name="calculateButton">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>

--- a/ui/besttimesimpl.ui
+++ b/ui/besttimesimpl.ui
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>besttimesimpl</class>
+ <widget class="QDialog" name="besttimesimpl">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>617</width>
+    <height>504</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Best Times</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Distance:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="distanceBox">
+     <property name="editable">
+      <bool>true</bool>
+     </property>
+     <item>
+      <property name="text">
+       <string>50</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>100</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>500</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>1000</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>1500</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="4">
+    <widget class="QTableWidget" name="tableWidget">
+     <column>
+      <property name="text">
+       <string>Date</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Time</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Pool</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Distance</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Duration</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Speed</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Total</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QPushButton" name="pushButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Calculate</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="3">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>besttimesimpl</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>besttimesimpl</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/ui/summary.ui
+++ b/ui/summary.ui
@@ -529,6 +529,13 @@
         <item>
          <layout class="QHBoxLayout" name="control_buttons">
           <item>
+           <widget class="QPushButton" name="bestTimesButton">
+            <property name="text">
+             <string>Best Times</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <spacer name="horizontalSpacer_3">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -848,6 +855,22 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>bestTimesButton</sender>
+   <signal>clicked()</signal>
+   <receiver>Summary</receiver>
+   <slot>bestTimesButton()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>543</x>
+     <y>619</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>478</x>
+     <y>322</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>selectedDate(QDate)</slot>
@@ -864,5 +887,6 @@
   <slot>printButton()</slot>
   <slot>setSelected()</slot>
   <slot>on_check_clicked()</slot>
+  <slot>bestTimesButton()</slot>
  </slots>
 </ui>


### PR DESCRIPTION
The times are taken from the **begin** of all sets with an equal or longer distance.

If the distance requested is not a multiple, we take enough lanes to go just longer. For this reason the best sorting is on **speed** (which is set by default).

Anyway table is sortable on all columns.
