### PR TITLE
Some improvements in table widget items.

### DIFF
--- a/poolview.pro
+++ b/poolview.pro
@@ -48,9 +48,11 @@ HEADERS = src/uploadimpl.h src/syncimpl.h src/configimpl.h src/summaryimpl.h src
     src/poolmate.h \
     src/logging.h \
     src/FIT.hpp src/stdintfwd.hpp src/GarminConvert.hpp \
-    src/besttimesimpl.h
+    src/besttimesimpl.h \
+    src/utilities.h
 SOURCES = src/uploadimpl.cpp src/syncimpl.cpp src/configimpl.cpp src/summaryimpl.cpp src/main.cpp src/graphwidget.cpp src/datastore.cpp src/poolmate.c src/calendar.cpp \
     src/podlink.cpp \
     src/podlive.cpp \
     src/FIT.cpp src/GarminConvert.cpp \
-    src/besttimesimpl.cpp
+    src/besttimesimpl.cpp \
+    src/utilities.cpp

--- a/src/besttimesimpl.cpp
+++ b/src/besttimesimpl.cpp
@@ -44,25 +44,25 @@ namespace
         const int row = table->rowCount();
         table->setRowCount(row + 1);
 
-        QTableWidgetItem * dateItem = createReadOnlyItem(QVariant(workout.date));
+        QTableWidgetItem * dateItem = createTableWidgetItem(QVariant(workout.date));
         table->setItem(row, 0, dateItem);
 
-        QTableWidgetItem * timeItem = createReadOnlyItem(QVariant(workout.time));
+        QTableWidgetItem * timeItem = createTableWidgetItem(QVariant(workout.time));
         table->setItem(row, 1, timeItem);
 
-        QTableWidgetItem * poolItem = createReadOnlyItem(QVariant(workout.pool));
+        QTableWidgetItem * poolItem = createTableWidgetItem(QVariant(workout.pool));
         table->setItem(row, 2, poolItem);
 
-        QTableWidgetItem * distanceItem = createReadOnlyItem(QVariant(distance));
+        QTableWidgetItem * distanceItem = createTableWidgetItem(QVariant(distance));
         table->setItem(row, 3, distanceItem);
 
-        QTableWidgetItem * durationItem = createReadOnlyItem(QVariant(duration.toString()));
+        QTableWidgetItem * durationItem = createTableWidgetItem(QVariant(duration.toString()));
         table->setItem(row, 4, durationItem);
 
-        QTableWidgetItem * speedItem = createReadOnlyItem(QVariant(speed));
+        QTableWidgetItem * speedItem = createTableWidgetItem(QVariant(speed));
         table->setItem(row, 5, speedItem);
 
-        QTableWidgetItem * totalItem = createReadOnlyItem(QVariant(total));
+        QTableWidgetItem * totalItem = createTableWidgetItem(QVariant(total));
         table->setItem(row, 6, totalItem);
     }
 }

--- a/src/besttimesimpl.cpp
+++ b/src/besttimesimpl.cpp
@@ -18,19 +18,10 @@
 
 #include "besttimesimpl.h"
 #include "datastore.h"
+#include "utilities.h"
 
 namespace
 {
-    QTableWidgetItem * createReadOnlyItem(const QVariant & content, int horizAlignment)
-    {
-        QTableWidgetItem * item = new QTableWidgetItem();
-        item->setFlags(item->flags() ^ Qt::ItemIsEditable);
-        item->setData(Qt::DisplayRole, content);
-        item->setTextAlignment(horizAlignment | Qt::AlignVCenter);
-
-        return item;
-    }
-
     void addSet(const Set & set, const Workout & workout, const int numberOfLanes, QTableWidget * table)
     {
         const int distance = workout.pool * numberOfLanes;
@@ -53,25 +44,25 @@ namespace
         const int row = table->rowCount();
         table->setRowCount(row + 1);
 
-        QTableWidgetItem * dateItem = createReadOnlyItem(QVariant(workout.date), Qt::AlignLeft);
+        QTableWidgetItem * dateItem = createReadOnlyItem(QVariant(workout.date));
         table->setItem(row, 0, dateItem);
 
-        QTableWidgetItem * timeItem = createReadOnlyItem(QVariant(workout.time), Qt::AlignLeft);
+        QTableWidgetItem * timeItem = createReadOnlyItem(QVariant(workout.time));
         table->setItem(row, 1, timeItem);
 
-        QTableWidgetItem * poolItem = createReadOnlyItem(QVariant(workout.pool), Qt::AlignRight);
+        QTableWidgetItem * poolItem = createReadOnlyItem(QVariant(workout.pool));
         table->setItem(row, 2, poolItem);
 
-        QTableWidgetItem * distanceItem = createReadOnlyItem(QVariant(distance), Qt::AlignRight);
+        QTableWidgetItem * distanceItem = createReadOnlyItem(QVariant(distance));
         table->setItem(row, 3, distanceItem);
 
-        QTableWidgetItem * durationItem = createReadOnlyItem(QVariant(duration.toString()), Qt::AlignRight);
+        QTableWidgetItem * durationItem = createReadOnlyItem(QVariant(duration.toString()));
         table->setItem(row, 4, durationItem);
 
-        QTableWidgetItem * speedItem = createReadOnlyItem(QVariant(speed), Qt::AlignRight);
+        QTableWidgetItem * speedItem = createReadOnlyItem(QVariant(speed));
         table->setItem(row, 5, speedItem);
 
-        QTableWidgetItem * totalItem = createReadOnlyItem(QVariant(total), Qt::AlignRight);
+        QTableWidgetItem * totalItem = createReadOnlyItem(QVariant(total));
         table->setItem(row, 6, totalItem);
     }
 }
@@ -144,5 +135,6 @@ void BestTimesImpl::on_calculateButton_clicked()
         }
     }
 
+    timesTable->resizeColumnsToContents();
     timesTable->setSortingEnabled(true);
 }

--- a/src/summaryimpl.cpp
+++ b/src/summaryimpl.cpp
@@ -266,13 +266,13 @@ void SummaryImpl::fillWorkouts( const std::vector<Workout>& workouts)
             item = createReadOnlyItem(QVariant(i->totalduration.toString()));
             workoutGrid->setItem( row, col++, item );
 
-            item = createReadOnlyItem(QVariant(i->cal));
-            workoutGrid->setItem( row, col++, item );
-
             item = createReadOnlyItem(QVariant(i->lengths));
             workoutGrid->setItem( row, col++, item );
 
             item = createReadOnlyItem(QVariant(i->totaldistance));
+            workoutGrid->setItem( row, col++, item );
+
+            item = createReadOnlyItem(QVariant(i->cal));
             workoutGrid->setItem( row, col++, item );
 
             item = createReadOnlyItem(QVariant(i->rest.toString()));
@@ -317,6 +317,9 @@ void SummaryImpl::fillLengths( const Set& set)
         uint col=0;
         QTableWidgetItem *item;
 
+        item = createReadOnlyItem(QVariant(1 + row));
+        lengthGrid->setItem( row, col++, item );
+
         item = createReadOnlyItem(QVariant(set.times[row]));
         lengthGrid->setItem( row, col++, item );
 
@@ -354,10 +357,13 @@ void SummaryImpl::fillSets( const std::vector<Set>& sets)
         item = createReadOnlyItem(QVariant(i->duration.toString()));
         setGrid->setItem( row, col++, item );
 
-        item = createReadOnlyItem(QVariant(i->strk));
+        item = createReadOnlyItem(QVariant(i->lens));
         setGrid->setItem( row, col++, item );
 
         item = createReadOnlyItem(QVariant(i->dist));
+        setGrid->setItem( row, col++, item );
+
+        item = createReadOnlyItem(QVariant(i->strk));
         setGrid->setItem( row, col++, item );
 
         item = createReadOnlyItem(QVariant(i->speed));

--- a/src/summaryimpl.cpp
+++ b/src/summaryimpl.cpp
@@ -255,30 +255,30 @@ void SummaryImpl::fillWorkouts( const std::vector<Workout>& workouts)
         int col=0;
         QTableWidgetItem *item;
 
-        item = createReadOnlyItem(QVariant(i->date));
+        item = createTableWidgetItem(QVariant(i->date));
         workoutGrid->setItem( row, col++, item );
 
-        item = createReadOnlyItem(QVariant(i->time));
+        item = createTableWidgetItem(QVariant(i->time));
         workoutGrid->setItem( row, col++, item );
 
         if (i->type == "Swim" || i->type=="SwimHR")
         {
-            item = createReadOnlyItem(QVariant(i->pool));
+            item = createTableWidgetItem(QVariant(i->pool));
             workoutGrid->setItem( row, col++, item );
 
-            item = createReadOnlyItem(QVariant(i->totalduration.toString()));
+            item = createTableWidgetItem(QVariant(i->totalduration.toString()));
             workoutGrid->setItem( row, col++, item );
 
-            item = createReadOnlyItem(QVariant(i->lengths));
+            item = createTableWidgetItem(QVariant(i->lengths));
             workoutGrid->setItem( row, col++, item );
 
-            item = createReadOnlyItem(QVariant(i->totaldistance));
+            item = createTableWidgetItem(QVariant(i->totaldistance));
             workoutGrid->setItem( row, col++, item );
 
-            item = createReadOnlyItem(QVariant(i->cal));
+            item = createTableWidgetItem(QVariant(i->cal));
             workoutGrid->setItem( row, col++, item );
 
-            item = createReadOnlyItem(QVariant(i->rest.toString()));
+            item = createTableWidgetItem(QVariant(i->rest.toString()));
             workoutGrid->setItem( row, col++, item );
         }
         row++;
@@ -320,17 +320,17 @@ void SummaryImpl::fillLengths( const Set& set)
         uint col=0;
         QTableWidgetItem *item;
 
-        item = createReadOnlyItem(QVariant(1 + row));
+        item = createTableWidgetItem(QVariant(1 + row));
         lengthGrid->setItem( row, col++, item );
 
-        item = createReadOnlyItem(QVariant(set.times[row]));
+        item = createTableWidgetItem(QVariant(set.times[row]));
         lengthGrid->setItem( row, col++, item );
 
-        item = createReadOnlyItem(QVariant(set.strokes[row]));
+        item = createTableWidgetItem(QVariant(set.strokes[row]));
         lengthGrid->setItem( row, col++, item );
 
         if ((int)set.styles.size() > row) {
-            item = createReadOnlyItem(QVariant(set.styles[row]));
+            item = createTableWidgetItem(QVariant(set.styles[row]));
             lengthGrid->setItem( row, col++, item );
         }
     }
@@ -354,28 +354,28 @@ void SummaryImpl::fillSets( const std::vector<Set>& sets)
         int col=0;
         QTableWidgetItem *item;
 
-        item = createReadOnlyItem(QVariant(i->set));
+        item = createTableWidgetItem(QVariant(i->set));
         setGrid->setItem( row, col++, item );
 
-        item = createReadOnlyItem(QVariant(i->duration.toString()));
+        item = createTableWidgetItem(QVariant(i->duration.toString()));
         setGrid->setItem( row, col++, item );
 
-        item = createReadOnlyItem(QVariant(i->lens));
+        item = createTableWidgetItem(QVariant(i->lens));
         setGrid->setItem( row, col++, item );
 
-        item = createReadOnlyItem(QVariant(i->dist));
+        item = createTableWidgetItem(QVariant(i->dist));
         setGrid->setItem( row, col++, item );
 
-        item = createReadOnlyItem(QVariant(i->strk));
+        item = createTableWidgetItem(QVariant(i->strk));
         setGrid->setItem( row, col++, item );
 
-        item = createReadOnlyItem(QVariant(i->speed));
+        item = createTableWidgetItem(QVariant(i->speed));
         setGrid->setItem( row, col++, item );
 
-        item = createReadOnlyItem(QVariant(i->effic));
+        item = createTableWidgetItem(QVariant(i->effic));
         setGrid->setItem( row, col++, item );
 
-        item = createReadOnlyItem(QVariant(i->rate));
+        item = createTableWidgetItem(QVariant(i->rate));
         setGrid->setItem( row, col++, item );
 
         row++;

--- a/src/summaryimpl.cpp
+++ b/src/summaryimpl.cpp
@@ -33,6 +33,7 @@
 #include "datastore.h"
 #include "configimpl.h"
 #include "besttimesimpl.h"
+#include "utilities.h"
 
 
 SummaryImpl::SummaryImpl( QWidget * parent, Qt::WindowFlags f) 
@@ -228,15 +229,6 @@ void SummaryImpl::fillWorkouts( const std::vector<Workout>& workouts)
     
     workoutGrid->setRowCount(workouts.size());
 
-    workoutGrid->setColumnWidth(0,85); //date
-    workoutGrid->setColumnWidth(1,50); //time
-    workoutGrid->setColumnWidth(2,35); //pool
-    workoutGrid->setColumnWidth(3,70); //duration
-    workoutGrid->setColumnWidth(4,45); //cal
-    workoutGrid->setColumnWidth(5,55); //length
-    workoutGrid->setColumnWidth(6,60); //total m
-    workoutGrid->setColumnWidth(7,60); //rest
-
     std::map<QDate, CalendarWidget::Totals> day_totals;
     std::map<QDate, int> day_nums;
 
@@ -260,38 +252,30 @@ void SummaryImpl::fillWorkouts( const std::vector<Workout>& workouts)
         int col=0;
         QTableWidgetItem *item;
 
-        item = new QTableWidgetItem(i->date.toString(Qt::SystemLocaleShortDate));
-        item->setFlags(Qt::ItemIsSelectable|Qt::ItemIsEnabled);
+        item = createReadOnlyItem(QVariant(i->date));
         workoutGrid->setItem( row, col++, item );
 
-        item = new QTableWidgetItem(i->time.toString(QString("HH:mm")));
-        item->setFlags(Qt::ItemIsSelectable|Qt::ItemIsEnabled);
+        item = createReadOnlyItem(QVariant(i->time));
         workoutGrid->setItem( row, col++, item );
 
         if (i->type == "Swim" || i->type=="SwimHR")
         {
-            item = new QTableWidgetItem(QString::number(i->pool));
-            item->setFlags(Qt::ItemIsSelectable|Qt::ItemIsEnabled);
+            item = createReadOnlyItem(QVariant(i->pool));
             workoutGrid->setItem( row, col++, item );
 
-            item = new QTableWidgetItem(i->totalduration.toString());
-            item->setFlags(Qt::ItemIsSelectable|Qt::ItemIsEnabled);
+            item = createReadOnlyItem(QVariant(i->totalduration.toString()));
             workoutGrid->setItem( row, col++, item );
 
-            item = new QTableWidgetItem(QString::number(i->cal));
-            item->setFlags(Qt::ItemIsSelectable|Qt::ItemIsEnabled);
+            item = createReadOnlyItem(QVariant(i->cal));
             workoutGrid->setItem( row, col++, item );
 
-            item = new QTableWidgetItem(QString::number(i->lengths));
-            item->setFlags(Qt::ItemIsSelectable|Qt::ItemIsEnabled);
+            item = createReadOnlyItem(QVariant(i->lengths));
             workoutGrid->setItem( row, col++, item );
 
-            item = new QTableWidgetItem(QString::number(i->totaldistance));
-            item->setFlags(Qt::ItemIsSelectable|Qt::ItemIsEnabled);
+            item = createReadOnlyItem(QVariant(i->totaldistance));
             workoutGrid->setItem( row, col++, item );
 
-            item = new QTableWidgetItem(i->rest.toString());
-            item->setFlags(Qt::ItemIsSelectable|Qt::ItemIsEnabled);
+            item = createReadOnlyItem(QVariant(i->rest.toString()));
             workoutGrid->setItem( row, col++, item );
         }
         row++;
@@ -315,6 +299,7 @@ void SummaryImpl::fillWorkouts( const std::vector<Workout>& workouts)
     }
 
     workoutGrid->selectRow(workoutGrid->rowCount()-1);
+    workoutGrid->resizeColumnsToContents();
 
     //populate graph
     setData(ds->Workouts());
@@ -326,50 +311,36 @@ void SummaryImpl::fillLengths( const Set& set)
     lengthGrid->clearContents();
     lengthGrid->setRowCount(set.lens);
 
-    lengthGrid->setColumnWidth(0,50);
-    lengthGrid->setColumnWidth(1,50);
-
     int row;
     for (row = 0; row < set.lens; ++row)
     {
         uint col=0;
         QTableWidgetItem *item;
 
-        item = new QTableWidgetItem(QString::number(set.times[row]));
-        item->setFlags(Qt::ItemIsSelectable|Qt::ItemIsEnabled);
+        item = createReadOnlyItem(QVariant(set.times[row]));
         lengthGrid->setItem( row, col++, item );
 
-        item = new QTableWidgetItem(QString::number(set.strokes[row]));
-        item->setFlags(Qt::ItemIsSelectable|Qt::ItemIsEnabled);
+        item = createReadOnlyItem(QVariant(set.strokes[row]));
         lengthGrid->setItem( row, col++, item );
         
         if (set.styles.size() > row) {
-            item = new QTableWidgetItem(set.styles[row]);
-            item->setFlags(Qt::ItemIsSelectable|Qt::ItemIsEnabled);
+            item = createReadOnlyItem(QVariant(set.styles[row]));
             lengthGrid->setItem( row, col++, item );
         }
-        
     }
+    lengthGrid->resizeColumnsToContents();
 }
 
 void SummaryImpl::fillSets( const std::vector<Set>& sets)
 {
     // clearContents() does not reset selected line
     setGrid->setCurrentCell(0,0);
+
     setGrid->clearContents();
 
     std::vector<Set>::const_iterator i;
     
     setGrid->setRowCount(sets.size());
-
-    setGrid->setColumnWidth(0,35); //set
-    setGrid->setColumnWidth(1,70); //duration
-    setGrid->setColumnWidth(2,55); //strokes
-    setGrid->setColumnWidth(3,50); //dist
-    setGrid->setColumnWidth(4,50); //speed
-    setGrid->setColumnWidth(5,50); //effic
-    setGrid->setColumnWidth(6,50); //rate
-    setGrid->setColumnWidth(7,50); //rate
 
     int row=0;
     for (i=sets.begin(); i != sets.end(); ++i)
@@ -377,36 +348,30 @@ void SummaryImpl::fillSets( const std::vector<Set>& sets)
         int col=0;
         QTableWidgetItem *item;
 
-        item = new QTableWidgetItem(QString::number(i->set));
-        item->setFlags(Qt::ItemIsSelectable|Qt::ItemIsEnabled);
+        item = createReadOnlyItem(QVariant(i->set));
         setGrid->setItem( row, col++, item );
 
-        item = new QTableWidgetItem(i->duration.toString());
-        item->setFlags(Qt::ItemIsSelectable|Qt::ItemIsEnabled);
+        item = createReadOnlyItem(QVariant(i->duration.toString()));
         setGrid->setItem( row, col++, item );
 
-        item = new QTableWidgetItem(QString::number(i->strk));
-        item->setFlags(Qt::ItemIsSelectable|Qt::ItemIsEnabled);
+        item = createReadOnlyItem(QVariant(i->strk));
         setGrid->setItem( row, col++, item );
 
-        item = new QTableWidgetItem(QString::number(i->dist));
-        item->setFlags(Qt::ItemIsSelectable|Qt::ItemIsEnabled);
+        item = createReadOnlyItem(QVariant(i->dist));
         setGrid->setItem( row, col++, item );
 
-        item = new QTableWidgetItem(QString::number(i->speed));
-        item->setFlags(Qt::ItemIsSelectable|Qt::ItemIsEnabled);
+        item = createReadOnlyItem(QVariant(i->speed));
         setGrid->setItem( row, col++, item );
 
-        item = new QTableWidgetItem(QString::number(i->effic));
-        item->setFlags(Qt::ItemIsSelectable|Qt::ItemIsEnabled);
+        item = createReadOnlyItem(QVariant(i->effic));
         setGrid->setItem( row, col++, item );
 
-        item = new QTableWidgetItem(QString::number(i->rate));
-        item->setFlags(Qt::ItemIsSelectable|Qt::ItemIsEnabled);
+        item = createReadOnlyItem(QVariant(i->rate));
         setGrid->setItem( row, col++, item );
 
         row++;
     }
+    setGrid->resizeColumnsToContents();
 }
 
 //

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -3,7 +3,7 @@
 #include <QVariant>
 #include <QTableWidgetItem>
 
-QTableWidgetItem * createReadOnlyItem(const QVariant & content)
+QTableWidgetItem * createTableWidgetItem(const QVariant & content)
 {
     QTableWidgetItem * item = new QTableWidgetItem();
     item->setFlags(item->flags() ^ Qt::ItemIsEditable);

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -1,0 +1,15 @@
+#include "utilities.h"
+
+#include <QVariant>
+#include <QTableWidgetItem>
+
+QTableWidgetItem * createReadOnlyItem(const QVariant & content)
+{
+    QTableWidgetItem * item = new QTableWidgetItem();
+    item->setFlags(item->flags() ^ Qt::ItemIsEditable);
+    item->setData(Qt::DisplayRole, content);
+    item->setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
+
+    return item;
+}
+

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -5,6 +5,6 @@ class QTableWidgetItem;
 class QVariant;
 
 // ReadOnly, horizontal Right aligned, non editable
-QTableWidgetItem * createReadOnlyItem(const QVariant & content);
+QTableWidgetItem * createTableWidgetItem(const QVariant & content);
 
 #endif // UTILITIES_H

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -1,0 +1,10 @@
+#ifndef UTILITIES_H
+#define UTILITIES_H
+
+class QTableWidgetItem;
+class QVariant;
+
+// ReadOnly, horizontal Right aligned, non editable
+QTableWidgetItem * createReadOnlyItem(const QVariant & content);
+
+#endif // UTILITIES_H

--- a/ui/summary.ui
+++ b/ui/summary.ui
@@ -179,17 +179,17 @@
               </column>
               <column>
                <property name="text">
-                <string>Cal</string>
-               </property>
-              </column>
-              <column>
-               <property name="text">
                 <string>Lengths</string>
                </property>
               </column>
               <column>
                <property name="text">
                 <string>Total m</string>
+               </property>
+              </column>
+              <column>
+               <property name="text">
+                <string>Cal</string>
                </property>
               </column>
               <column>
@@ -278,12 +278,17 @@
               </column>
               <column>
                <property name="text">
-                <string>Strokes</string>
+                <string>Lengths</string>
                </property>
               </column>
               <column>
                <property name="text">
                 <string>Dist</string>
+               </property>
+              </column>
+              <column>
+               <property name="text">
+                <string>Strokes</string>
                </property>
               </column>
               <column>
@@ -335,6 +340,11 @@
               <attribute name="verticalHeaderDefaultSectionSize">
                <number>19</number>
               </attribute>
+              <column>
+               <property name="text">
+                <string>Length</string>
+               </property>
+              </column>
               <column>
                <property name="text">
                 <string>Time</string>


### PR DESCRIPTION
- common function to create all widgets (right justified seems to look better in all cases)
- stick to QVariant where possible to allow sorting (only swim durations are converted to strings otherwise default conversion looses seconds)
- resize columns after editing to fit content
- move more relevant values towards the left
- add number of lengths in set (this is the *first* thing I look at)
- add lane number