### PR TITLE
Fix Read/Save CSV pair

### DIFF
--- a/poolview.pro
+++ b/poolview.pro
@@ -49,7 +49,8 @@ HEADERS = src/uploadimpl.h src/syncimpl.h src/configimpl.h src/summaryimpl.h src
     src/logging.h \
     src/FIT.hpp src/stdintfwd.hpp src/GarminConvert.hpp \
     src/besttimesimpl.h \
-    src/utilities.h
+    src/utilities.h \
+    src/exerciseset.h
 SOURCES = src/uploadimpl.cpp src/syncimpl.cpp src/configimpl.cpp src/summaryimpl.cpp src/main.cpp src/graphwidget.cpp src/datastore.cpp src/poolmate.c src/calendar.cpp \
     src/podlink.cpp \
     src/podlive.cpp \

--- a/src/datastore.cpp
+++ b/src/datastore.cpp
@@ -131,16 +131,18 @@ bool ReadCSV( const std::string & name, std::vector<ExerciseSet>& dst )
     QFile file(name.c_str());
     if (file.open(QIODevice::ReadOnly))
     {
+        QTextStream in(&file);
+
         bool oldformat = false;
-        QString head = file.readLine(); //skip header
+        QString head = in.readLine(); //skip header
         if (head.contains("LogDate"))
         {
             oldformat = true;
         }
 
-        while (!file.atEnd())
+        while (!in.atEnd())
         {
-            QString line = file.readLine();
+            QString line = in.readLine();
             QStringList strings = line.split(",");
 
             if (strings.count())
@@ -235,7 +237,6 @@ bool ReadCSV( const std::string & name, std::vector<ExerciseSet>& dst )
                 dst.push_back(e);
             }
         }
-        file.close();
 
     }
     return true;


### PR DESCRIPTION
This is my swim data

http://pastebin.com/hwS6y5D3

when the app writes it out with SaveCSV there is a '\n' at the end of the len_styles which breaks the format and ReadCSV does not work any longer.

The '\n' seems to be a natural side effect of QFile::realLine().

On the other hand, QTextStream::readLine() strips the trailing '\n'. So this is the change.
The written file is not the same as the input as it contains a lot of ;;;;;;;;;; which I think mean len_styles with no information. But not I can re-read it.

Andrea
