### PR TITLE
Add a column to display how much time is not "accounted for" in a set.

### DIFF
--- a/src/summaryimpl.cpp
+++ b/src/summaryimpl.cpp
@@ -398,6 +398,29 @@ void SummaryImpl::fillSets( const std::vector<Set>& sets)
         item = createTableWidgetItem(QVariant(i->rate));
         setGrid->setItem( row, col++, item );
 
+        col++; // skip stroke
+
+        QTime actual = getActualSwimTime(*i);
+        QTime duration = i->duration;
+        QString sign("");   // nothign for +
+        if (actual > duration)
+        {
+            // we display as negative
+            std::swap(actual, duration);
+            sign = "-";
+        }
+
+        // now duration >= actual
+        const int gapMS = actual.msecsTo(duration);
+
+        // < 1sec: no display
+        if (gapMS >= 1000)
+        {
+            const QTime gap = QTime(0, 0).addMSecs(gapMS);
+            item = createTableWidgetItem(QVariant(sign + gap.toString()));
+            setGrid->setItem( row, col++, item );
+        }
+
         row++;
     }
     setGrid->resizeColumnsToContents();

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -2,6 +2,7 @@
 
 #include <QVariant>
 #include <QTableWidgetItem>
+#include "datastore.h"
 
 QTableWidgetItem * createTableWidgetItem(const QVariant & content)
 {
@@ -13,3 +14,14 @@ QTableWidgetItem * createTableWidgetItem(const QVariant & content)
     return item;
 }
 
+// sums the duration of all the lanes
+QTime getActualSwimTime(const Set & set)
+{
+    QTime duration(0, 0);
+
+    for (size_t i = 0; i < set.times.size(); ++i)
+    {
+        duration = duration.addMSecs(set.times[i] * 1000);
+    }
+    return duration;
+}

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -1,10 +1,16 @@
 #ifndef UTILITIES_H
 #define UTILITIES_H
 
+#include <QTime>
+
 class QTableWidgetItem;
 class QVariant;
+class Set;
 
 // ReadOnly, horizontal Right aligned, non editable
 QTableWidgetItem * createTableWidgetItem(const QVariant & content);
+
+// sums the duration of all the lanes
+QTime getActualSwimTime(const Set & set);
 
 #endif // UTILITIES_H

--- a/ui/summary.ui
+++ b/ui/summary.ui
@@ -311,6 +311,11 @@
                 <string>Stroke</string>
                </property>
               </column>
+              <column>
+               <property name="text">
+                <string>Gap</string>
+               </property>
+              </column>
              </widget>
             </item>
            </layout>


### PR DESCRIPTION
Avoid displaying a lot of 0. Minimum 1 sec.

This adds a column just for info to show how much time has been lost by the watch.
Causes are still unclear. It happens for me very often when I mix breaststroke and freestyle.

Some breaststroke lanes have simply disappeared entirely, they are probably all together in this lost time.

(goes without saying that I do not change style halfway through a lane)
(and the watch does not miss a turn, it misses the entire lane, the other lanes recorded are correct)
