### PR TITLE
Gap time editor.

### DIFF
--- a/poolview.pro
+++ b/poolview.pro
@@ -43,7 +43,8 @@ FORMS = ui/summary.ui \
     ui/config.ui \
     ui/upload.ui \
     ui/besttimesimpl.ui \
-    ui/analysis.ui
+    ui/analysis.ui \
+    ui/editgap.ui
 HEADERS = src/uploadimpl.h \
     src/syncimpl.h \
     src/configimpl.h \
@@ -63,7 +64,8 @@ HEADERS = src/uploadimpl.h \
     src/utilities.h \
     src/exerciseset.h \
     src/poda.h \
-    src/analysisimpl.h
+    src/analysisimpl.h \
+    src/editgap.h
 SOURCES = src/uploadimpl.cpp \
     src/syncimpl.cpp \
     src/configimpl.cpp \
@@ -80,7 +82,8 @@ SOURCES = src/uploadimpl.cpp \
     src/besttimesimpl.cpp \
     src/utilities.cpp \
     src/poda.cpp \
-    src/analysisimpl.cpp
+    src/analysisimpl.cpp \
+    src/editgap.cpp
 
 DISTFILES +=
 

--- a/src/datastore.cpp
+++ b/src/datastore.cpp
@@ -533,5 +533,5 @@ void DataStore::replaceSet( int wid, int sid, const Set & newSet )
 
     // should we update max_eff, avg_eff, min_eff and cal as well?
 
-    // and not done yet, mark the ds as modified so it will be saved down
+    changed = true;
 }

--- a/src/datastore.cpp
+++ b/src/datastore.cpp
@@ -521,3 +521,17 @@ const std::vector<Workout>& DataStore::Workouts() const
     return workouts;
 }
 
+void DataStore::replaceSet( int wid, int sid, const Set & newSet )
+{
+    Workout & workout = workouts[wid];
+    const Set oldSet = workout.sets[sid];
+    workout.sets[sid] = newSet;
+
+    // update workout totals
+    workout.lengths += newSet.lens - oldSet.lens;
+    workout.totaldistance = workout.lengths * workout.pool;
+
+    // should we update max_eff, avg_eff, min_eff and cal as well?
+
+    // and not done yet, mark the ds as modified so it will be saved down
+}

--- a/src/datastore.h
+++ b/src/datastore.h
@@ -81,6 +81,9 @@ public:
     void remove(int id);
     void removeSet( int wid, int sid );
 
+    // Replace set in workout
+    void replaceSet( int wid, int sid, const Set & newSet );
+
     // Remove all exercises at date
     void remove( QDateTime dt );
 

--- a/src/editgap.cpp
+++ b/src/editgap.cpp
@@ -63,6 +63,9 @@ void EditGap::setOriginalSet(const Set * _set)
     const double recordedTime = original->duration.msecsSinceStartOfDay() / 1000;
     gap = recordedTime - actualTime;
 
+    gapTimeUsedSpin->setMaximum(gap);
+    gapTimeUsedSpin->setValue(gap);
+
     // these never change
     displaySet(setGrid, 0, *original);
     gapTimeEdit->setText(formatSecondsToTimeWithMillis(gap));
@@ -71,7 +74,7 @@ void EditGap::setOriginalSet(const Set * _set)
     lengthsEquivalentEdit->setText(QString("%1").arg(equivalent, 0, 'f', 2));
 
     // simulate the 0 to update GUI properly
-    on_lengthsSpin_valueChanged(0);
+    calculate();
 }
 
 const Set & EditGap::getModifiedSet() const
@@ -79,20 +82,27 @@ const Set & EditGap::getModifiedSet() const
     return modified;
 }
 
-void EditGap::update()
+void EditGap::on_newLengthsSpin_valueChanged(int /* extraLengths */)
 {
-    // only update modified row on grid
-    displaySet(setGrid, 1, modified);
+    calculate();
 }
 
-void EditGap::on_lengthsSpin_valueChanged(int extraLengths)
+void EditGap::on_gapTimeUsedSpin_valueChanged(double /* time */)
+{
+    calculate();
+}
+
+void EditGap::calculate()
 {
     modified = *original;
 
+    const int extraLengths = newLengthsSpin->value();
+
     if (extraLengths > 0)
     {
-        const double average = roundTo8thSecond(gap / extraLengths);
-        averageTimeEdit->setText(formatSecondsToTimeWithMillis(average));
+        const double gapTime = gapTimeUsedSpin->value();
+        const double average = roundTo8thSecond(gapTime / extraLengths);
+        lengthTimeEdit->setText(formatSecondsToTimeWithMillis(average));
 
         for (int i = 0; i < extraLengths; ++i)
         {
@@ -115,7 +125,8 @@ void EditGap::on_lengthsSpin_valueChanged(int extraLengths)
     }
     else
     {
-        averageTimeEdit->clear();
+        lengthTimeEdit->clear();
     }
-    update();
+    // only update modified row on grid
+    displaySet(setGrid, 1, modified);
 }

--- a/src/editgap.cpp
+++ b/src/editgap.cpp
@@ -3,26 +3,21 @@
 
 namespace
 {
-    void extractSetData(const Set & set, int pool, int & lengths, QTime & duration, double & average, double &speed)
+    void extractSetData(const Set & set, int & lengths, QTime & duration, double & average)
     {
         lengths = set.times.size();
         duration = getActualSwimTime(set);
 
         const double actualTime = duration.msecsSinceStartOfDay() / 1000.0;
         average = actualTime / lengths;
-
-        const double distance = lengths * pool;
-        const double recordedTime = set.duration.msecsSinceStartOfDay() / 1000.0;
-        speed = recordedTime / distance * 100.0;
     }
 
-    void displaySet(QTableWidget * grid, int row, const Set & set, int pool)
+    void displaySet(QTableWidget * grid, int row, const Set & set)
     {
         int lengths;
         QTime actual;
         double average;
-        double speed;
-        extractSetData(set, pool, lengths, actual, average, speed);
+        extractSetData(set, lengths, actual, average);
 
         QTableWidgetItem * lengthsItem = createTableWidgetItem(QVariant(lengths));
         grid->setItem(row, 0, lengthsItem);
@@ -36,7 +31,7 @@ namespace
         QTableWidgetItem * averageItem = createTableWidgetItem(QVariant(average));
         grid->setItem(row, 3, averageItem);
 
-        QTableWidgetItem * speedItem = createTableWidgetItem(QVariant(speed));
+        QTableWidgetItem * speedItem = createTableWidgetItem(QVariant(set.speed));
         grid->setItem(row, 4, speedItem);
     }
 }
@@ -47,24 +42,22 @@ EditGap::EditGap(QWidget *parent) :
     setupUi(this);
 }
 
-void EditGap::setOriginalSet(const Set * _set, int _pool)
+void EditGap::setOriginalSet(const Set * _set)
 {
     original = _set;
-    pool = _pool;
     modified = *original;
 
     int lengths;
     QTime duration;
-    double speed;
     double average;
-    extractSetData(*original, pool, lengths, duration, average, speed);
+    extractSetData(*original, lengths, duration, average);
 
-    const double actual = duration.msecsSinceStartOfDay() / 1000.0;
-    const double recorded = original->duration.msecsSinceStartOfDay() / 1000;
-    gap = recorded - actual;
+    const double actualTime = duration.msecsSinceStartOfDay() / 1000.0;
+    const double recordedTime = original->duration.msecsSinceStartOfDay() / 1000;
+    gap = recordedTime - actualTime;
 
     // these never change
-    displaySet(setGrid, 0, *original, pool);
+    displaySet(setGrid, 0, *original);
     gapTimeLCD->display(gap);
 
     const double equivalent = gap / average;
@@ -75,24 +68,41 @@ void EditGap::setOriginalSet(const Set * _set, int _pool)
 
 void EditGap::update()
 {
-    displaySet(setGrid, 1, modified, pool);
+    // only update modified row on grid
+    displaySet(setGrid, 1, modified);
 }
 
-
-void EditGap::on_lengthsSpin_valueChanged(int arg1)
+void EditGap::on_lengthsSpin_valueChanged(int extraLengths)
 {
     modified = *original;
 
-    if (arg1 > 0)
+    if (extraLengths > 0)
     {
-        const double average = gap / arg1;
+        const double average = roundTo8thSecond(gap / extraLengths);
+        averageLCD->display(average);
 
-        for (size_t i = 0; i < arg1; ++i)
+        for (int i = 0; i < extraLengths; ++i)
         {
+            // add a lengths keeping the rest syncronised
             ++modified.lens;
+
             modified.times.push_back(average);
             modified.strokes.push_back(modified.strk);
         }
+
+        if (!modified.styles.empty())
+        {
+            // add empty string at the end
+            modified.styles.resize(modified.lens);
+        }
+
+        modified.dist = modified.dist * modified.lens / original->lens; // this should be exact integer arithmetic
+        modified.effic = modified.effic * original->lens / modified.lens;
+        modified.speed = modified.speed * original->lens / modified.lens;
+    }
+    else
+    {
+        averageLCD->display(0.0);
     }
     update();
 }

--- a/src/editgap.cpp
+++ b/src/editgap.cpp
@@ -53,7 +53,6 @@ EditGap::EditGap(QWidget *parent) :
 void EditGap::setOriginalSet(const Set * _set)
 {
     original = _set;
-    modified = *original;
 
     int lengths;
     QTime duration;
@@ -71,7 +70,13 @@ void EditGap::setOriginalSet(const Set * _set)
     const double equivalent = gap / average;
     lengthsEquivalentEdit->setText(QString("%1").arg(equivalent, 0, 'f', 2));
 
-    update();
+    // simulate the 0 to update GUI properly
+    on_lengthsSpin_valueChanged(0);
+}
+
+const Set & EditGap::getModifiedSet() const
+{
+    return modified;
 }
 
 void EditGap::update()

--- a/src/editgap.cpp
+++ b/src/editgap.cpp
@@ -1,3 +1,21 @@
+/*
+ * This file is part of PoolViewer
+ * Copyright (c) 2015 Andrea Odetti
+ *
+ * PoolViewer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * PoolViewer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PoolViewer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "editgap.h"
 #include "utilities.h"
 

--- a/src/editgap.cpp
+++ b/src/editgap.cpp
@@ -50,7 +50,7 @@ EditGap::EditGap(QWidget *parent) :
     setupUi(this);
 }
 
-void EditGap::setOriginalSet(const Set * _set)
+bool EditGap::setOriginalSet(const Set * _set)
 {
     original = _set;
 
@@ -62,6 +62,12 @@ void EditGap::setOriginalSet(const Set * _set)
     const double actualTime = duration.msecsSinceStartOfDay() / 1000.0;
     const double recordedTime = original->duration.msecsSinceStartOfDay() / 1000;
     gap = recordedTime - actualTime;
+
+    if (gap < 1)
+    {
+        // no point in doing anything
+        return false;
+    }
 
     gapTimeUsedSpin->setMaximum(gap);
     gapTimeUsedSpin->setValue(gap);
@@ -75,6 +81,8 @@ void EditGap::setOriginalSet(const Set * _set)
 
     // simulate the 0 to update GUI properly
     calculate();
+
+    return true;
 }
 
 const Set & EditGap::getModifiedSet() const

--- a/src/editgap.cpp
+++ b/src/editgap.cpp
@@ -1,0 +1,98 @@
+#include "editgap.h"
+#include "utilities.h"
+
+namespace
+{
+    void extractSetData(const Set & set, int pool, int & lengths, QTime & duration, double & average, double &speed)
+    {
+        lengths = set.times.size();
+        duration = getActualSwimTime(set);
+
+        const double actualTime = duration.msecsSinceStartOfDay() / 1000.0;
+        average = actualTime / lengths;
+
+        const double distance = lengths * pool;
+        const double recordedTime = set.duration.msecsSinceStartOfDay() / 1000.0;
+        speed = recordedTime / distance * 100.0;
+    }
+
+    void displaySet(QTableWidget * grid, int row, const Set & set, int pool)
+    {
+        int lengths;
+        QTime actual;
+        double average;
+        double speed;
+        extractSetData(set, pool, lengths, actual, average, speed);
+
+        QTableWidgetItem * lengthsItem = createTableWidgetItem(QVariant(lengths));
+        grid->setItem(row, 0, lengthsItem);
+
+        QTableWidgetItem * displayedItem = createTableWidgetItem(QVariant(set.duration.toString()));
+        grid->setItem(row, 1, displayedItem);
+
+        QTableWidgetItem * actualItem = createTableWidgetItem(QVariant(actual.toString()));
+        grid->setItem(row, 2, actualItem);
+
+        QTableWidgetItem * averageItem = createTableWidgetItem(QVariant(average));
+        grid->setItem(row, 3, averageItem);
+
+        QTableWidgetItem * speedItem = createTableWidgetItem(QVariant(speed));
+        grid->setItem(row, 4, speedItem);
+    }
+}
+
+EditGap::EditGap(QWidget *parent) :
+    QDialog(parent)
+{
+    setupUi(this);
+}
+
+void EditGap::setOriginalSet(const Set * _set, int _pool)
+{
+    original = _set;
+    pool = _pool;
+    modified = *original;
+
+    int lengths;
+    QTime duration;
+    double speed;
+    double average;
+    extractSetData(*original, pool, lengths, duration, average, speed);
+
+    const double actual = duration.msecsSinceStartOfDay() / 1000.0;
+    const double recorded = original->duration.msecsSinceStartOfDay() / 1000;
+    gap = recorded - actual;
+
+    // these never change
+    displaySet(setGrid, 0, *original, pool);
+    gapTimeLCD->display(gap);
+
+    const double equivalent = gap / average;
+    equivalentLCD->display(equivalent);
+
+    update();
+}
+
+void EditGap::update()
+{
+    displaySet(setGrid, 1, modified, pool);
+}
+
+
+void EditGap::on_lengthsSpin_valueChanged(int arg1)
+{
+    modified = *original;
+
+    if (arg1 > 0)
+    {
+        const double average = gap / arg1;
+
+        for (size_t i = 0; i < arg1; ++i)
+        {
+            ++modified.lens;
+            modified.times.push_back(average);
+            modified.strokes.push_back(modified.strk);
+        }
+    }
+    update();
+}

--- a/src/editgap.cpp
+++ b/src/editgap.cpp
@@ -12,6 +12,13 @@ namespace
         average = actualTime / lengths;
     }
 
+    QString formatSecondsToTimeWithMillis(const double value)
+    {
+        QTime time = QTime(0, 0).addMSecs(value * 1000);
+        QString result = time.toString("mm:ss.zzz");
+        return result;
+    }
+
     void displaySet(QTableWidget * grid, int row, const Set & set)
     {
         int lengths;
@@ -28,12 +35,13 @@ namespace
         QTableWidgetItem * actualItem = createTableWidgetItem(QVariant(actual.toString()));
         grid->setItem(row, 2, actualItem);
 
-        QTableWidgetItem * averageItem = createTableWidgetItem(QVariant(average));
+        QTableWidgetItem * averageItem = createTableWidgetItem(QVariant(formatSecondsToTimeWithMillis(average)));
         grid->setItem(row, 3, averageItem);
 
         QTableWidgetItem * speedItem = createTableWidgetItem(QVariant(set.speed));
         grid->setItem(row, 4, speedItem);
     }
+
 }
 
 EditGap::EditGap(QWidget *parent) :
@@ -58,10 +66,10 @@ void EditGap::setOriginalSet(const Set * _set)
 
     // these never change
     displaySet(setGrid, 0, *original);
-    gapTimeLCD->display(gap);
+    gapTimeEdit->setText(formatSecondsToTimeWithMillis(gap));
 
     const double equivalent = gap / average;
-    equivalentLCD->display(equivalent);
+    lengthsEquivalentEdit->setText(QString("%1").arg(equivalent, 0, 'f', 2));
 
     update();
 }
@@ -79,7 +87,7 @@ void EditGap::on_lengthsSpin_valueChanged(int extraLengths)
     if (extraLengths > 0)
     {
         const double average = roundTo8thSecond(gap / extraLengths);
-        averageLCD->display(average);
+        averageTimeEdit->setText(formatSecondsToTimeWithMillis(average));
 
         for (int i = 0; i < extraLengths; ++i)
         {
@@ -102,7 +110,7 @@ void EditGap::on_lengthsSpin_valueChanged(int extraLengths)
     }
     else
     {
-        averageLCD->display(0.0);
+        averageTimeEdit->clear();
     }
     update();
 }

--- a/src/editgap.h
+++ b/src/editgap.h
@@ -11,7 +11,11 @@ class EditGap : public QDialog, private Ui::EditGap
 public:
     explicit EditGap(QWidget *parent = 0);
 
-    void setOriginalSet(const Set * _set);
+    // returns true if it is possible to turn a gap into lanes
+    // false in case: negative gap
+    //                or gap < 1 sec
+    // if false, one should NOT call exec!
+    bool setOriginalSet(const Set * _set);
     const Set & getModifiedSet() const;
 
 private slots:

--- a/src/editgap.h
+++ b/src/editgap.h
@@ -1,3 +1,21 @@
+/*
+ * This file is part of PoolViewer
+ * Copyright (c) 2015 Andrea Odetti
+ *
+ * PoolViewer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * PoolViewer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PoolViewer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef EDITGAP_H
 #define EDITGAP_H
 

--- a/src/editgap.h
+++ b/src/editgap.h
@@ -11,7 +11,7 @@ class EditGap : public QDialog, private Ui::EditGap
 public:
     explicit EditGap(QWidget *parent = 0);
 
-    void setOriginalSet(const Set * _set, int _pool);
+    void setOriginalSet(const Set * _set);
 
 private slots:
     void on_lengthsSpin_valueChanged(int arg1);
@@ -19,8 +19,6 @@ private slots:
 private:
 
     void update();
-
-    int pool;
 
     const Set * original;
     Set modified;

--- a/src/editgap.h
+++ b/src/editgap.h
@@ -15,11 +15,13 @@ public:
     const Set & getModifiedSet() const;
 
 private slots:
-    void on_lengthsSpin_valueChanged(int arg1);
+    void on_gapTimeUsedSpin_valueChanged(double arg1);
+
+    void on_newLengthsSpin_valueChanged(int arg1);
 
 private:
 
-    void update();
+    void calculate();
 
     const Set * original;
     Set modified;

--- a/src/editgap.h
+++ b/src/editgap.h
@@ -1,0 +1,31 @@
+#ifndef EDITGAP_H
+#define EDITGAP_H
+
+#include "ui_editgap.h"
+#include "datastore.h"
+
+class EditGap : public QDialog, private Ui::EditGap
+{
+    Q_OBJECT
+
+public:
+    explicit EditGap(QWidget *parent = 0);
+
+    void setOriginalSet(const Set * _set, int _pool);
+
+private slots:
+    void on_lengthsSpin_valueChanged(int arg1);
+
+private:
+
+    void update();
+
+    int pool;
+
+    const Set * original;
+    Set modified;
+
+    double gap;
+};
+
+#endif // EDITGAP_H

--- a/src/editgap.h
+++ b/src/editgap.h
@@ -12,6 +12,7 @@ public:
     explicit EditGap(QWidget *parent = 0);
 
     void setOriginalSet(const Set * _set);
+    const Set & getModifiedSet() const;
 
 private slots:
     void on_lengthsSpin_valueChanged(int arg1);

--- a/src/editgap.h
+++ b/src/editgap.h
@@ -33,7 +33,7 @@ public:
     // false in case: negative gap
     //                or gap < 1 sec
     // if false, one should NOT call exec!
-    bool setOriginalSet(const Set * _set);
+    bool setOriginalSet(const Set * _set, int _pool);
     const Set & getModifiedSet() const;
 
 private slots:
@@ -46,6 +46,7 @@ private:
     void calculate();
 
     const Set * original;
+    int pool;
     Set modified;
 
     double gap;

--- a/src/summaryimpl.cpp
+++ b/src/summaryimpl.cpp
@@ -589,7 +589,7 @@ void SummaryImpl::editButton()
             const Set& set = sets[setGrid->currentRow()];
 
             EditGap editGap(this);
-            editGap.setOriginalSet(&set, workout.pool);
+            editGap.setOriginalSet(&set);
 
             editGap.exec();
         }

--- a/src/summaryimpl.cpp
+++ b/src/summaryimpl.cpp
@@ -589,16 +589,17 @@ void SummaryImpl::editButton()
             const Set& set = sets[setrow];
 
             EditGap editGap(this);
-            editGap.setOriginalSet(&set);
-
-            if (editGap.exec() == QDialog::Accepted)
+            if (editGap.setOriginalSet(&set))
             {
-                const Set & modified = editGap.getModifiedSet();
-                ds->replaceSet(row, setrow, modified);
+                if (editGap.exec() == QDialog::Accepted)
+                {
+                    const Set & modified = editGap.getModifiedSet();
+                    ds->replaceSet(row, setrow, modified);
 
-                // this is the same as what happens for deleteSet()
-                // but it does not update the workout line
-                workoutSelected();
+                    // this is the same as what happens for deleteSet()
+                    // but it does not update the workout line
+                    workoutSelected();
+                }
             }
         }
     }

--- a/src/summaryimpl.cpp
+++ b/src/summaryimpl.cpp
@@ -34,6 +34,7 @@
 #include "configimpl.h"
 #include "besttimesimpl.h"
 #include "analysisimpl.h"
+#include "editgap.h"
 #include "utilities.h"
 
 
@@ -577,6 +578,22 @@ void SummaryImpl::deleteClick()
 
 void SummaryImpl::editButton()
 {
+    if (setSel)
+    {
+        int setrow = setGrid->currentRow();
+        int row = workoutGrid->currentRow();
+        if (row >= 0 && setrow >= 0)
+        {
+            const Workout & workout = ds->Workouts()[row];
+            const std::vector<Set>& sets = workout.sets;
+            const Set& set = sets[setGrid->currentRow()];
+
+            EditGap editGap(this);
+            editGap.setOriginalSet(&set, workout.pool);
+
+            editGap.exec();
+        }
+    }
 }
 
 //

--- a/src/summaryimpl.cpp
+++ b/src/summaryimpl.cpp
@@ -586,12 +586,20 @@ void SummaryImpl::editButton()
         {
             const Workout & workout = ds->Workouts()[row];
             const std::vector<Set>& sets = workout.sets;
-            const Set& set = sets[setGrid->currentRow()];
+            const Set& set = sets[setrow];
 
             EditGap editGap(this);
             editGap.setOriginalSet(&set);
 
-            editGap.exec();
+            if (editGap.exec() == QDialog::Accepted)
+            {
+                const Set & modified = editGap.getModifiedSet();
+                ds->replaceSet(row, setrow, modified);
+
+                // this is the same as what happens for deleteSet()
+                // but it does not update the workout line
+                workoutSelected();
+            }
         }
     }
 }

--- a/src/summaryimpl.cpp
+++ b/src/summaryimpl.cpp
@@ -589,7 +589,7 @@ void SummaryImpl::editButton()
             const Set& set = sets[setrow];
 
             EditGap editGap(this);
-            if (editGap.setOriginalSet(&set))
+            if (editGap.setOriginalSet(&set, workout.pool))
             {
                 if (editGap.exec() == QDialog::Accepted)
                 {

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -1,3 +1,21 @@
+/*
+ * This file is part of PoolViewer
+ * Copyright (c) 2015 Andrea Odetti
+ *
+ * PoolViewer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * PoolViewer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PoolViewer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "utilities.h"
 
 #include <QVariant>

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -2,6 +2,8 @@
 
 #include <QVariant>
 #include <QTableWidgetItem>
+#include <cmath>
+
 #include "datastore.h"
 
 QTableWidgetItem * createTableWidgetItem(const QVariant & content)
@@ -24,4 +26,11 @@ QTime getActualSwimTime(const Set & set)
         duration = duration.addMSecs(set.times[i] * 1000);
     }
     return duration;
+}
+
+// mimic watch that rounds to 8th of a second
+double roundTo8thSecond(double value)
+{
+    const double result = round(value * 8.0) / 8.0;
+    return result;
 }

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -1,3 +1,21 @@
+/*
+ * This file is part of PoolViewer
+ * Copyright (c) 2015 Andrea Odetti
+ *
+ * PoolViewer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * PoolViewer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PoolViewer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef UTILITIES_H
 #define UTILITIES_H
 

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -13,4 +13,7 @@ QTableWidgetItem * createTableWidgetItem(const QVariant & content);
 // sums the duration of all the lanes
 QTime getActualSwimTime(const Set & set);
 
+// mimic watch that rounds to 8th of a second
+double roundTo8thSecond(double value);
+
 #endif // UTILITIES_H

--- a/ui/editgap.ui
+++ b/ui/editgap.ui
@@ -85,6 +85,20 @@
      <item row="1" column="1">
       <widget class="QLCDNumber" name="equivalentLCD"/>
      </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Average times of new lengths:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLCDNumber" name="averageLCD">
+       <property name="digitCount">
+        <number>4</number>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item row="4" column="0">

--- a/ui/editgap.ui
+++ b/ui/editgap.ui
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>EditGap</class>
+ <widget class="QDialog" name="EditGap">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>606</width>
+    <height>277</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QTableWidget" name="setGrid">
+     <row>
+      <property name="text">
+       <string>Original</string>
+      </property>
+     </row>
+     <row>
+      <property name="text">
+       <string>Modified</string>
+      </property>
+     </row>
+     <column>
+      <property name="text">
+       <string>Lengths</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Displayed</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Actual</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Average</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Speed</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="2" column="1">
+      <widget class="QSpinBox" name="lengthsSpin"/>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Gap time:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Lengths to add:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLCDNumber" name="gapTimeLCD"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Lengths equivalent:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLCDNumber" name="equivalentLCD"/>
+     </item>
+    </layout>
+   </item>
+   <item row="4" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>EditGap</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>EditGap</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/ui/editgap.ui
+++ b/ui/editgap.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>649</width>
-    <height>320</height>
+    <width>654</width>
+    <height>363</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -55,8 +55,8 @@
    </item>
    <item row="2" column="0">
     <layout class="QGridLayout" name="gridLayout_2">
-     <item row="2" column="1">
-      <widget class="QSpinBox" name="lengthsSpin">
+     <item row="3" column="1">
+      <widget class="QSpinBox" name="newLengthsSpin">
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
@@ -69,7 +69,7 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>New lengths:</string>
@@ -83,15 +83,18 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
+     <item row="5" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
-        <string>Average times of new lengths:</string>
+        <string>Time of new lengths:</string>
        </property>
       </widget>
      </item>
      <item row="0" column="1">
       <widget class="QLineEdit" name="gapTimeEdit">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
@@ -102,6 +105,9 @@
      </item>
      <item row="1" column="1">
       <widget class="QLineEdit" name="lengthsEquivalentEdit">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
@@ -110,13 +116,33 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
-      <widget class="QLineEdit" name="averageTimeEdit">
+     <item row="5" column="1">
+      <widget class="QLineEdit" name="lengthTimeEdit">
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
        <property name="readOnly">
         <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Gap time allocated:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QDoubleSpinBox" name="gapTimeUsedSpin">
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="decimals">
+        <number>3</number>
+       </property>
+       <property name="singleStep">
+        <double>0.125000000000000</double>
        </property>
       </widget>
      </item>

--- a/ui/editgap.ui
+++ b/ui/editgap.ui
@@ -56,7 +56,11 @@
    <item row="2" column="0">
     <layout class="QGridLayout" name="gridLayout_2">
      <item row="2" column="1">
-      <widget class="QSpinBox" name="lengthsSpin"/>
+      <widget class="QSpinBox" name="lengthsSpin">
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
      </item>
      <item row="0" column="0">
       <widget class="QLabel" name="label">
@@ -72,18 +76,12 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
-      <widget class="QLCDNumber" name="gapTimeLCD"/>
-     </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Lengths equivalent:</string>
        </property>
       </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLCDNumber" name="equivalentLCD"/>
      </item>
      <item row="3" column="0">
       <widget class="QLabel" name="label_4">
@@ -92,10 +90,33 @@
        </property>
       </widget>
      </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="gapTimeEdit">
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="lengthsEquivalentEdit">
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
      <item row="3" column="1">
-      <widget class="QLCDNumber" name="averageLCD">
-       <property name="digitCount">
-        <number>4</number>
+      <widget class="QLineEdit" name="averageTimeEdit">
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/ui/editgap.ui
+++ b/ui/editgap.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>606</width>
-    <height>277</height>
+    <width>649</width>
+    <height>320</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -72,7 +72,7 @@
      <item row="2" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
-        <string>Lengths to add:</string>
+        <string>New lengths:</string>
        </property>
       </widget>
      </item>

--- a/ui/summary.ui
+++ b/ui/summary.ui
@@ -381,7 +381,7 @@
           <item>
            <widget class="QPushButton" name="editButton">
             <property name="enabled">
-             <bool>false</bool>
+             <bool>true</bool>
             </property>
             <property name="text">
              <string>Edit</string>


### PR DESCRIPTION
This allows to convert (part of) the gap time into lanes.
The user is presented with an overview of the set before and after modifications.

New lengths have the same number of strokes as the average of the existing lengths.

It is triggered by clicking "Edit" when setSel = true and only if there is positive gap time.

Complete refresh of the GUI and datastore consistency wait for a more general solution.
