### PR TITLE
Fix crash when there are no workouts and the user clicks the table.

### DIFF
--- a/src/summaryimpl.cpp
+++ b/src/summaryimpl.cpp
@@ -473,10 +473,9 @@ void SummaryImpl::workoutSelected()
 
             //    viewCombo->setCurrentIndex((int)WORKOUTS);
             calendarWidget->setSelectedDate( ds->Workouts()[row].date );
+            fillLengths(ds->Workouts()[row]);
         }
         setData(ds->Workouts());
-
-        fillLengths(ds->Workouts()[row]);
 
         graphWidget->update();
         volumeWidget->update();


### PR DESCRIPTION
If workouts are empty this crashes it.
