### PR TITLE
Ensure that when a set is edited, the workout totals are synchronised:

### DIFF
--- a/src/edit.cpp
+++ b/src/edit.cpp
@@ -151,6 +151,7 @@ bool Edit::getModifiedWrk(Workout &wrk) const
     else
     {
         wrk = modified;
+        synchroniseWorkout(wrk);
         return true;
     }
 }

--- a/src/summaryimpl.cpp
+++ b/src/summaryimpl.cpp
@@ -698,24 +698,29 @@ void SummaryImpl::on_lengthGrid_itemSelectionChanged()
             // ids are on item at column 0
             const QTableWidgetItem * id_item = lengthGrid->item(row, 0);
 
-            const int s_id = id_item->data(SET_ID).value<int>();
-            const int l_id = id_item->data(LENGTH_ID).value<int>();
+            if (id_item)
+            {
+                const int s_id = id_item->data(SET_ID).value<int>();
+                const int l_id = id_item->data(LENGTH_ID).value<int>();
 
-            const Set& set = sets[s_id];
+                const Set& set = sets[s_id];
 
-            duration = duration.addMSecs(set.times[l_id] * 1000);
-            ++n;
+                duration = duration.addMSecs(set.times[l_id] * 1000);
+                ++n;
+            }
         }
 
-        const int distance = n * workout.pool;
-        const int speed = duration.msecsSinceStartOfDay() / distance / 10;
+        if (n)
+        {
+            const int distance = n * workout.pool;
+            const int speed = duration.msecsSinceStartOfDay() / distance / 10;
 
-        QString str = QString::number(n) + " - "  + duration.toString() + " - " + QString::number(speed);
+            QString str = QString::number(n) + " - "  + duration.toString() + " - " + QString::number(speed);
 
-        status->setText(str);
+            status->setText(str);
+            return;
+        }
     }
-    else
-    {
-        status->setText(QString());
-    }
+
+    status->setText(QString());
 }

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -52,3 +52,47 @@ double roundTo8thSecond(double value)
     const double result = round(value * 8.0) / 8.0;
     return result;
 }
+
+// synchronise workout
+void synchroniseWorkout(Workout & workout)
+{
+    const size_t numberOfSets = workout.sets.size();
+
+    int lengths = 0;
+    QTime rest;
+    QTime totalDuration(0, 0);
+    for (size_t i = 0; i < numberOfSets; ++i)
+    {
+        const Set & set = workout.sets[i];
+        lengths += set.lens;
+        if (rest.isValid())
+        {
+            rest = rest.addMSecs(set.rest.msecsSinceStartOfDay());
+        }
+        else
+        {
+            // if the sets do not have rest
+            // we keep the existing rest on the workout
+            // (see end of setsToWorkouts() in datastore.cpp)
+            if (set.rest.isValid())
+            {
+                rest = set.rest;
+            }
+        }
+        totalDuration = totalDuration.addMSecs(set.duration.msecsSinceStartOfDay());
+    }
+
+    // always update lenghts and total
+    workout.lengths = lengths;
+    workout.totaldistance = lengths * workout.pool;
+
+    if (rest.isValid())
+    {
+        workout.rest = rest;
+        // otherwise leave it unchanged
+    }
+
+    // use the actual rest to compute total duration
+    totalDuration = totalDuration.addMSecs(workout.rest.msecsSinceStartOfDay());
+    workout.totalduration = totalDuration;
+}

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -24,6 +24,7 @@
 class QTableWidgetItem;
 class QVariant;
 class Set;
+class Workout;
 
 // ReadOnly, horizontal Right aligned, non editable
 QTableWidgetItem * createTableWidgetItem(const QVariant & content);
@@ -33,5 +34,8 @@ QTime getActualSwimTime(const Set & set);
 
 // mimic watch that rounds to 8th of a second
 double roundTo8thSecond(double value);
+
+// synchronise workout
+void synchroniseWorkout(Workout & workout);
 
 #endif // UTILITIES_H


### PR DESCRIPTION
lenghts, duration and rest (the rest is left untouched if the sets do not include it)

The change in summaryimpl.cpp is to fix a crash in the program, due to the fact
that the length grid had a size bigger than the actual number of lengths.

If the workouts are synchronised, this is not necessary any longer,
but it is left to ensure bad data does not cause a crash.

Andrea