### PR TITLE
Podlive: refactor some of the serial port communication

### DIFF
--- a/src/podbase.h
+++ b/src/podbase.h
@@ -27,8 +27,7 @@
 #include <QMetaType>
 Q_DECLARE_METATYPE(QSerialPort::SerialPortError)
 
-uint32_t crc32a(unsigned char *message, int len);
-void dataToWorkouts( unsigned char *buf, std::vector<ExerciseSet>& data );
+void dataToWorkouts(const unsigned char *buf, std::vector<ExerciseSet>& data );
 
 class PodBase : public QThread
 {

--- a/src/podlive.cpp
+++ b/src/podlive.cpp
@@ -380,7 +380,7 @@ void PodLive::handleError(QSerialPort::SerialPortError serialPortError)
     }
 }
 
-bool PodLive::download(const QScopedPointer<QSerialPort> & serialPort, QByteArray& readData, const QByteArray &handshake)
+bool PodLive::download(const QScopedPointer<QSerialPort> & serialPort, const QByteArray &handshake, QByteArray& readData)
 {
     const uint32_t req = *(const uint32_t*)handshake.data();
 
@@ -495,7 +495,7 @@ void PodLive::run()
             emit info("Transferring.");
 
             state = TRANSFER;
-            if (download(serialPort, readData, handshake))
+            if (download(serialPort, handshake, readData))
             {
                 state = DONE;
                 emit info("Complete.");

--- a/src/podlive.cpp
+++ b/src/podlive.cpp
@@ -196,15 +196,14 @@ void PodLive::getData( std::vector<ExerciseSet>& exdata )
     if (readData.isEmpty() || state != DONE)
         return;
 
-    uint16_t type;
     const char *buffer = (const char*) readData.data();
 
     do
     {
         const unsigned char *ptr = (unsigned char*)buffer;
-        type = *(const uint16_t*)ptr;
+        const uint16_t workoutBlockType = *(const uint16_t*)ptr;
 
-        if (type == 0) // workout header
+        if (workoutBlockType == 0) // workout header
         {
             std::vector<ExerciseSet> exercises;
             int lengths=0, totaldistance=0, calories=0;
@@ -239,11 +238,11 @@ void PodLive::getData( std::vector<ExerciseSet>& exdata )
                 DEBUG("%02d/%02d/%04d %02d:%02d:%02d %d\n", D,M,Y,h,m,s,sets);
                 do
                 {
-                    uint16_t type =  *(const uint16_t*)ptr;
+                    const uint16_t setBlockType =  *(const uint16_t*)ptr;
 
-                    DEBUG("Type %04x: ", type);
+                    DEBUG("SetBlockType %04x: ", setBlockType);
 
-                    if (type == 0x100)      // length field
+                    if (setBlockType == 0x100)      // length field
                     {
                         double duration;
                         int strks;
@@ -265,7 +264,7 @@ void PodLive::getData( std::vector<ExerciseSet>& exdata )
                         times.push_back(duration);
                         strokes.push_back(strks);
                     }
-                    else if (type == 0x200) // set end
+                    else if (setBlockType == 0x200) // set end
                     {
                         int lens = ptr[2]; // + ((ptr[3]&0x7f)<<8); this isn't high bit
                         int h = ptr[3]&0x7f;

--- a/src/podlive.cpp
+++ b/src/podlive.cpp
@@ -24,7 +24,7 @@
 //CRC32 helper function for PoolmateLive protocol
 // Non-optimised crc32 calc.
 // Doesn't need to be fast so leave readable.
-uint32_t crc32a(unsigned char *message, int len)
+uint32_t crc32a(const unsigned char *message, int len)
 {
     int i, j;
     uint32_t crc;
@@ -120,12 +120,12 @@ void PodLive::getData( std::vector<ExerciseSet>& exdata )
         return;
 
     uint16_t type;
-    char *buffer = (char*) readData.data();
+    const char *buffer = (const char*) readData.data();
 
     do
     {
-        unsigned char *ptr = (unsigned char*)buffer;
-        type = *(uint16_t*)ptr;
+        const unsigned char *ptr = (unsigned char*)buffer;
+        type = *(const uint16_t*)ptr;
 
         if (type == 0) // workout header
         {
@@ -162,7 +162,7 @@ void PodLive::getData( std::vector<ExerciseSet>& exdata )
                 DEBUG("%02d/%02d/%04d %02d:%02d:%02d %d\n", D,M,Y,h,m,s,sets);
                 do
                 {
-                    uint16_t type =  *(uint16_t*)ptr;
+                    uint16_t type =  *(const uint16_t*)ptr;
 
                     DEBUG("Type %04x: ", type);
 
@@ -308,7 +308,7 @@ void PodLive::handleError(QSerialPort::SerialPortError serialPortError)
 unsigned char d1[] = {0x00, 0x63, 0x63, 0x00, 0x00, 0x00}; //5555 prefixed
 unsigned char d5[] = {0x00,0x06,0x80,0x00,0x00,0x00}; //Download start
 
-void display(QByteArray& data)
+void display(const QByteArray& data)
 {
     int i;
     DEBUG("%d :", data.length());
@@ -345,7 +345,7 @@ void read(const QScopedPointer<QSerialPort> & serialPort, unsigned long len)
     display(data);
 }
 
-void write(const QScopedPointer<QSerialPort> & serialPort, unsigned char* data, unsigned long len)
+void write(const QScopedPointer<QSerialPort> & serialPort, const unsigned char* data, unsigned long len)
 {
     QByteArray out((char*)data,len);
     serialPort->write(out);
@@ -353,7 +353,7 @@ void write(const QScopedPointer<QSerialPort> & serialPort, unsigned char* data, 
 }
 
 // prefix 0x55 packet
-void sendandstart(const QScopedPointer<QSerialPort> & serialPort, unsigned char* data, int len)
+void sendandstart(const QScopedPointer<QSerialPort> & serialPort, const unsigned char* data, int len)
 {
     uint32_t crc = crc32a(data,len);
 
@@ -368,7 +368,7 @@ void sendandstart(const QScopedPointer<QSerialPort> & serialPort, unsigned char*
 }
 
 // prefix 0xff packet
-void sendandwait(const QScopedPointer<QSerialPort> & serialPort, unsigned char* data, int len)
+void sendandwait(const QScopedPointer<QSerialPort> & serialPort, const unsigned char* data, int len)
 {
     uint32_t crc = crc32a(data,len);
 
@@ -386,7 +386,7 @@ void sendandwait(const QScopedPointer<QSerialPort> & serialPort, unsigned char* 
 bool PodLive::download(const QScopedPointer<QSerialPort> & serialPort, QByteArray& readData)
 {
     uint32_t req;
-    req = *(uint32_t*)data.data();
+    req = *(const uint32_t*)data.data();
 
     DEBUG("Bitflags: %04x\n", req); //bitflags
 

--- a/src/podlive.h
+++ b/src/podlive.h
@@ -49,7 +49,7 @@ private:
     QScopedPointer<QSerialPort> serialPort;
     QString      serialPortName;
     QByteArray   readData;
-    bool         download(const QScopedPointer<QSerialPort> & serialPort, QByteArray& readData, const QByteArray &handshake);
+    bool         download(const QScopedPointer<QSerialPort> & serialPort, const QByteArray &handshake, QByteArray& readData);
 
 };
 

--- a/src/podlive.h
+++ b/src/podlive.h
@@ -49,7 +49,7 @@ private:
     QScopedPointer<QSerialPort> serialPort;
     QString      serialPortName;
     QByteArray   readData;
-    bool         download(const QScopedPointer<QSerialPort> & serialPort, QByteArray& readData);
+    bool         download(const QScopedPointer<QSerialPort> & serialPort, QByteArray& readData, const QByteArray &handshake);
 
 };
 

--- a/src/podorig.cpp
+++ b/src/podorig.cpp
@@ -27,7 +27,7 @@ extern "C"
 #include "logging.h"
 #include "podorig.h"
 
-void dataToWorkouts( unsigned char *buf, std::vector<ExerciseSet>& data )
+void dataToWorkouts(const unsigned char *buf, std::vector<ExerciseSet>& data )
 {
     // some sort of checksum exists in 0x1000,1001,1002,1003
 //    int version = buf[0x1004];


### PR DESCRIPTION
The biggest change is that all communications go via the function sendAndWait() which ensures the CRC is correct.
Previously, the initial communication was not crc-checked (the bitFlags).

Removed global variable "data" to store the bytes read from the port.

Added a few cons here and there.

Andrea