### PR TITLE
Avoid the "missing slot fitButton()" warning.

### DIFF
--- a/src/summaryimpl.cpp
+++ b/src/summaryimpl.cpp
@@ -759,7 +759,7 @@ void SummaryImpl::on_lengthGrid_itemSelectionChanged()
     status->setText(QString());
 }
 
-void SummaryImpl::on_shareButton_clicked()
+void SummaryImpl::fitButton()
 {
     Export share(this);
     share.setDataStore(ds); // will populate our datastore

--- a/src/summaryimpl.h
+++ b/src/summaryimpl.h
@@ -58,25 +58,21 @@ public:
     void closeEvent(QCloseEvent *event);
 
  private slots:
-    virtual void selectedDate(QDate);
-    virtual void workoutSelected();
-    virtual void syncButton();
-    virtual void configButton();
-    virtual void editButton();
-    virtual void scaleChanged(int);
-    virtual void printButton();
-    virtual void onCheckClicked(bool);
-    virtual void analysisButton();
-
-    void on_lengthGrid_itemSelectionChanged();
-    void on_shareButton_clicked();
+    void selectedDate(QDate);
+    void workoutSelected();
+    void syncButton();
+    void configButton();
+    void editButton();
+    void scaleChanged(int);
+    void printButton();
+    void onCheckClicked(bool);
+    void analysisButton();
+    void fitButton();
 
 private:
+    void on_lengthGrid_itemSelectionChanged();
+
     DataStore *ds;
     Scale scale;
 };
 #endif
-
-
-
-


### PR DESCRIPTION
fitButton() is declared as slot in the .ui but it is never defined.
We can either remove the slot declaration form the .ui or implement it as a slot (I have taken the latter).

Moreover no need to make the slots virtual.

And on_lengthGrid_itemSelectionChanged is not a slot.

Signed-off-by: Andrea Odetti <mariofutire@gmail.com>