### PR TITLE
Fixed label clipping text in the config.ui dialog

### DIFF
--- a/ui/config.ui
+++ b/ui/config.ui
@@ -203,7 +203,7 @@
     <rect>
      <x>10</x>
      <y>10</y>
-     <width>381</width>
+     <width>400</width>
      <height>21</height>
     </rect>
    </property>


### PR DESCRIPTION
The "Specify type of poolmate pod, 'Type-A' pods are labelled
underneath." label was to small horizontally and was cutting off the end
of the label's text.

The label's size was increased to show the full text.