### PR TITLE
Added extra distances to analysisimpl.cpp

### DIFF
--- a/src/analysisimpl.cpp
+++ b/src/analysisimpl.cpp
@@ -24,8 +24,8 @@
 
 namespace
 {
-    const double distances[] = {25, 100, 400, 750, 1500, 1931, 3862, 5000};
-    const char * labels[] = {"25m", "100m", "400m", "750m", "1500m", "1931m (1.2ml)", "3862m (2.4ml)", "5000m"};
+    const double distances[] = {25, 100, 400, 750, 1000, 1250, 1500, 1931, 2000, 3862, 5000};
+    const char * labels[] = {"25m", "100m", "400m", "750m", "1000m", "1250m", "1500m", "1931m (1.2ml)", "2000m", "3862m (2.4ml)", "5000m"};
     const size_t numberOfRows = sizeof(distances) / sizeof(distances[0]);
 }
 


### PR DESCRIPTION
Added 1000m, 1250m and 2000m distances to the analysis dialog.

I wanted these distances for my own training and decided to add them.
These are all common distances for openwater swimming and believe that other poolview users will benefit from the addition these distances.